### PR TITLE
allow setting consumer key & secret in settings.json

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,2 +1,12 @@
-
 TwitMaker = Npm.require('twit');
+var keys;
+if (keys = Meteor.settings['twit']) {
+    TwitMakerSafe = function(access_token, access_token_secret) {
+        return new TwitMaker({
+            consumer_key: keys.consumer_key,
+            consumer_secret: keys.consumer_secret,
+            access_token: access_token,
+            access_token_secret: access_token_secret
+        })
+    }
+}

--- a/package.js
+++ b/package.js
@@ -1,14 +1,15 @@
-
-
 Package.describe({
-  summary: "Twitter API Client"
+    summary: "Twitter API Client"
 });
 
-Npm.depends({twit: "1.1.9"});
+Npm.depends({
+    twit: "1.1.9"
+});
 
-Package.on_use(function (api) {
-  if(api.export) {
-    api.export('TwitMaker');
-  }
-  api.add_files("main.js", "server");
+Package.on_use(function(api) {
+    if (api.export) {
+        api.export('TwitMaker');
+        api.export('TwitMakerSafe');
+    }
+    api.add_files("main.js", "server");
 });


### PR DESCRIPTION
Hi,

I created a small patch that introduces TwitMakerSafe. By using this function you can include your consumer key & secret in settings.json so you can use this in Methods without exposing your application credentials to the client.

Usage is simple, just include this in your settings:

```
"twit": {
    "consumer_key": "XXXXXXX",
    "consumer_secret": "XXXXX"
}
```

And instead of calling: 

```
var Twit = new TwitMaker({ consumer_key: "", consumer_secret: "", access_token: "", access_token_secret: "" });
```

You can just call:

```
var Twit = TwitMakerSafe(accessToken, accessTokenSecret);
```

(wrapped in a Meteor.isServer if)

I hope you'd like to pull this in.
