### PR TITLE
Updated package.js to use latest Twit NPM package.

### DIFF
--- a/package.js
+++ b/package.js
@@ -4,7 +4,7 @@ Package.describe({
   summary: "Twitter API Client"
 });
 
-Npm.depends({twit: "1.1.9"});
+Npm.depends({twit: "2.1.0"});
 
 Package.on_use(function (api) {
   if(api.export) {


### PR DESCRIPTION
Updated package.js to depend on the latest Twit NPM package (2.1.0).  The latest version allows application-only authentication which doesn't require user tokens.  This lets you perform GETS and have much higher limits.  This is useful if your application is only querying Twitter and not posting.

Will also update your readme to demonstrate the "application-only" method of initializing Twit.
